### PR TITLE
Standard filters (#315)

### DIFF
--- a/src/DotLiquid.Tests/StandardFilterTests.cs
+++ b/src/DotLiquid.Tests/StandardFilterTests.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Threading;
 using System.Linq;
 using NUnit.Framework;
+using System.Collections.Generic;
 
 namespace DotLiquid.Tests
 {
@@ -560,8 +561,18 @@ namespace DotLiquid.Tests
         public void TestUrlencode()
         {
             Assert.AreEqual("http%3A%2F%2Fdotliquidmarkup.org%2F", StandardFilters.UrlEncode("http://dotliquidmarkup.org/"));
+			Assert.AreEqual("Tetsuro+Takara", StandardFilters.UrlEncode("Tetsuro Takara"));
+			Assert.AreEqual("john%40liquid.com", StandardFilters.UrlEncode("john@liquid.com"));
             Assert.AreEqual(null, StandardFilters.UrlEncode(null));
         }
+		
+		[Test]
+        public void TestUrldecode()
+        {
+            Assert.AreEqual("'Stop!' said Fred", StandardFilters.UrlDecode("%27Stop%21%27+said+Fred"));
+            Assert.AreEqual(null, StandardFilters.UrlDecode(null));
+        }
+
 
         [Test]
         public void TestDefault()
@@ -580,5 +591,70 @@ namespace DotLiquid.Tests
             Assert.AreEqual(" ", StandardFilters.Capitalize(" "));
             Assert.AreEqual("That Is One Sentence.", StandardFilters.Capitalize("That is one sentence."));
         }
+		
+		[Test]
+        public void TestUniq()
+        {
+			CollectionAssert.AreEqual(new[] { "ants", "bugs", "bees" }, StandardFilters.Uniq(new string[] { "ants", "bugs", "bees", "bugs", "ants" }));
+            CollectionAssert.AreEqual(new string[] {}, StandardFilters.Uniq(new string[] {}));
+            Assert.AreEqual(null, StandardFilters.Uniq(null));
+			Assert.AreEqual(new List<object> {5}, StandardFilters.Uniq(5));
+        }
+		
+		[Test]
+        public void TestAbs()
+        {
+			Assert.AreEqual(0, StandardFilters.Abs("notNumber"));
+            Assert.AreEqual(10, StandardFilters.Abs(10));
+            Assert.AreEqual(5, StandardFilters.Abs(-5));
+            Assert.AreEqual(19.86, StandardFilters.Abs(19.86));
+			Assert.AreEqual(19.86, StandardFilters.Abs(-19.86));
+            Assert.AreEqual(10, StandardFilters.Abs("10"));
+            Assert.AreEqual(5, StandardFilters.Abs("-5"));
+            Assert.AreEqual(30.60, StandardFilters.Abs("30.60"));
+            Assert.AreEqual(0, StandardFilters.Abs("30.60a"));
+        }
+		
+		[Test]
+        public void TestAtLeast()
+        {
+			Assert.AreEqual("notNumber", StandardFilters.AtLeast("notNumber", 5));
+			Assert.AreEqual(5, StandardFilters.AtLeast(5, 5));
+			Assert.AreEqual(5, StandardFilters.AtLeast(3, 5));
+			Assert.AreEqual(6, StandardFilters.AtLeast(6, 5));
+			Assert.AreEqual(10, StandardFilters.AtLeast(10, 5));
+			Assert.AreEqual(9.85, StandardFilters.AtLeast(9.85, 5));
+			Assert.AreEqual(5, StandardFilters.AtLeast(3.56, 5));
+			Assert.AreEqual(10, StandardFilters.AtLeast("10", 5));
+			Assert.AreEqual(5, StandardFilters.AtLeast("4", 5));
+			Assert.AreEqual("10a", StandardFilters.AtLeast("10a", 5));
+			Assert.AreEqual("4b", StandardFilters.AtLeast("4b", 5));
+		}
+		
+		[Test]
+        public void TestAtMost()
+        {
+			Assert.AreEqual("notNumber", StandardFilters.AtMost("notNumber", 5));
+			Assert.AreEqual(5, StandardFilters.AtMost(5, 5));
+			Assert.AreEqual(3, StandardFilters.AtMost(3, 5));
+			Assert.AreEqual(5, StandardFilters.AtMost(6, 5));
+			Assert.AreEqual(5, StandardFilters.AtMost(10, 5));
+			Assert.AreEqual(5, StandardFilters.AtMost(9.85, 5));
+			Assert.AreEqual(3.56, StandardFilters.AtMost(3.56, 5));
+			Assert.AreEqual(5, StandardFilters.AtMost("10", 5));
+			Assert.AreEqual(4, StandardFilters.AtMost("4", 5));
+			Assert.AreEqual("4a", StandardFilters.AtMost("4a", 5));
+			Assert.AreEqual("10b", StandardFilters.AtMost("10b", 5));
+		}
+		
+		[Test]
+        public void TestCompact()
+        {
+			CollectionAssert.AreEqual(new[] { "business", "celebrities", "lifestyle", "sports", "technology" }, StandardFilters.Compact(new string[] { "business", null, "celebrities", null, null, "lifestyle", "sports", null, "technology", null}));
+            CollectionAssert.AreEqual(new[] { "business", "celebrities"}, StandardFilters.Compact(new string[] { "business", "celebrities" }));
+            Assert.AreEqual(new List<object> { 5 }, StandardFilters.Compact(5));
+            CollectionAssert.AreEqual(new string[] { }, StandardFilters.Compact(new string[] { }));
+            Assert.AreEqual(null, StandardFilters.Compact(null));
+		}
     }
 }

--- a/src/DotLiquid/StandardFilters.cs
+++ b/src/DotLiquid/StandardFilters.cs
@@ -93,7 +93,19 @@ namespace DotLiquid
         {
             return input == null
                 ? input
-                : Uri.EscapeDataString(input);
+                : System.Net.WebUtility.UrlEncode(input);
+        }
+		
+		/// <summary>
+        /// convert a input string to URLDECODE
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+		public static string UrlDecode(string input)
+        {
+            return input == null
+                ? input
+                : System.Net.WebUtility.UrlDecode(input);
         }
 
         /// <summary>
@@ -666,6 +678,112 @@ namespace DotLiquid
                                       , leftType: input.GetType()
                                       , rightType: operand.GetType() )
                                     .DynamicInvoke(input, operand);
+        }
+		
+		/// <summary>
+        /// Removes any duplicate elements in an array.
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        public static IEnumerable Uniq(object input)
+        {
+            if (input == null)
+                return null;
+
+            List<object> ary;
+            if (input is IEnumerable)
+                ary = ((IEnumerable) input).Flatten().Cast<object>().ToList();
+            else
+            { 
+                ary = new List<object>(new[] { input });
+            }
+
+            if (!ary.Any())
+                return ary;
+
+            return ary.Distinct().ToList();
+        }
+		
+		/// <summary>
+        /// Returns the absolute value of a number.
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+		public static double Abs(object input)
+        {
+            Double n;
+            return Double.TryParse(input.ToString(), System.Globalization.NumberStyles.Number, CultureInfo.CurrentCulture, out n) ? Math.Abs(n) : 0;
+        }
+		
+		/// <summary>
+        /// Limits a number to a minimum value.
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+		public static object AtLeast(object input, object atLeast)
+        {
+            double n;
+            var inputNumber = Double.TryParse(input.ToString(), System.Globalization.NumberStyles.Number, CultureInfo.CurrentCulture, out n);
+
+            double min;
+            var atLeastNumber = Double.TryParse(atLeast.ToString(), System.Globalization.NumberStyles.Number, CultureInfo.CurrentCulture, out min);
+
+            if (inputNumber && atLeastNumber)
+            {
+                return (double)((double)min > (double)n ? min : n);
+            }
+            else
+            {
+                return input;
+            }
+        }
+
+		/// <summary>
+        /// Limits a number to a maximum value.
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        public static object AtMost(object input, object atMost)
+        {
+            double n;
+            var inputNumber = Double.TryParse(input.ToString(), System.Globalization.NumberStyles.Number, CultureInfo.CurrentCulture, out n);
+
+            double max;
+            var atMostNumber = Double.TryParse(atMost.ToString(), System.Globalization.NumberStyles.Number, CultureInfo.CurrentCulture, out max);
+
+            if (inputNumber && atMostNumber)
+            {
+                return (double)((double)max < (double)n ? max : n);
+            }
+            else
+            {
+                return input;
+            }
+        }
+		
+		/// <summary>
+        /// Removes any nil values from an array.
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+		public static IEnumerable Compact(object input)
+        {
+            if (input == null)
+                return null;
+
+            List<object> ary;
+            if (input is IEnumerable)
+                ary = ((IEnumerable)input).Flatten().Cast<object>().ToList();
+            else
+            {
+                ary = new List<object>(new[] { input });
+            }
+
+            if (!ary.Any())
+                return ary;
+
+            ary.RemoveAll(item => item == null);
+            return ary;
         }
     }
 


### PR DESCRIPTION
Added the Uniq and UrlDecode decode filters.
Uniq:  Removes any duplicate elements in an array.
UrlDecode:  convert a input string to URLDECODE

Added Abs filter: Returns the absolute value of a number.

When the input is not a number, 0 is returned (same behaviour as the Ruby's implementation): https://github.com/Shopify/liquid/blob/0c802aba175aefb5cfb7e40c13c892075e70ffa5/lib/liquid/standardfilters.rb